### PR TITLE
Add root docker tag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       #    password: ${{ secrets.PYPI_API_TOKEN }}
 
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image [non-root]
         uses: mr-smithers-excellent/docker-build-push@v6
         with:
           # options related to BUILDing the docker image:
@@ -39,6 +39,21 @@ jobs:
           platform: linux/amd64,linux/arm64,linux/arm/v7
           image: psmqtt
           addLatest: true
+          # options related to PUSHing the docker image:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.PAT_TOKEN_FOR_GITHUB }}
+
+      - name: Build and push Docker image [root]
+        uses: mr-smithers-excellent/docker-build-push@v6
+        with:
+          # options related to BUILDing the docker image:
+          dockerfile: ./Dockerfile
+          multiPlatform: true
+          platform: linux/amd64,linux/arm64,linux/arm/v7
+          image: psmqtt
+          buildArgs: USER=root
+          tags: root
           # options related to PUSHing the docker image:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
This PR is adding a new build of psmqtt docker container with the 'root' tag where psmqtt runs as root process, to ease interfacing with pySMART  and SMART monitoring tools